### PR TITLE
Simplifies command line options

### DIFF
--- a/spec/server/MainSpec.ts
+++ b/spec/server/MainSpec.ts
@@ -4,7 +4,6 @@ import { parseArgs, isParseArgsResultFail, isParseArgsResultSuccess } from "../.
 describe("Main", () => {
   context("parseArgs", () => {
     const validArgs: { [key: string]: string } = {
-      "--socketTimeout": "10000",
       "--port": "8080",
       "--bundlePath": "/path/to/bundle",
     };
@@ -18,34 +17,6 @@ describe("Main", () => {
 
       return flatArgs;
     }
-
-    it(`parses socketTimeout`, () => {
-      const args = { ...validArgs, "--socketTimeout": "1000" };
-
-      const result = parseArgs(flatten(args));
-
-      if (isParseArgsResultSuccess(result)) {
-        expect(result.socketTimeout).to.eql(1000);
-      } else {
-        expect("<success>").to.eql(result);
-      }
-    });
-
-    it(`fails when socketTimeout is missing`, () => {
-      const { "--socketTimeout": _, ...args } = validArgs;
-
-      const result = parseArgs(flatten(args));
-
-      expect(isParseArgsResultFail(result)).to.be.true;
-    });
-
-    it(`fails when socketTimeout is not a number`, () => {
-      const args = { ...validArgs, "--socketTimeout": "not a number" };
-
-      const result = parseArgs(flatten(args));
-
-      expect(isParseArgsResultFail(result)).to.be.true;
-    });
 
     it(`parses port`, () => {
       const args = { ...validArgs, "--port": "9090" };
@@ -73,30 +44,6 @@ describe("Main", () => {
       const result = parseArgs(flatten(args));
 
       expect(isParseArgsResultFail(result)).to.be.true;
-    });
-
-    it(`parses keepAlive`, () => {
-      const args = flatten(validArgs).concat(["--keepAlive"])
-
-      const result = parseArgs(args);
-
-      if (isParseArgsResultSuccess(result)) {
-        expect(result.keepAlive).to.be.true;
-      } else {
-        expect("<success>").to.eql(result);
-      }
-    });
-
-    it(`defaults keepAlive to false when not specified`, () => {
-      const { "--keepAlive": _, ...args } = validArgs;
-
-      const result = parseArgs(flatten(args));
-
-      if (isParseArgsResultSuccess(result)) {
-        expect(result.keepAlive).to.be.false;
-      } else {
-        expect("<success>").to.eql(result);
-      }
     });
 
     it(`parses bundlePath`, () => {

--- a/src/server/Main.ts
+++ b/src/server/Main.ts
@@ -108,7 +108,9 @@ type ServerShuttingDownState = {
   doneShuttingDownPromise: Promise<void>;
 }
 
-async function startServer(app: Express.Application, port: number, keepAlive: boolean, socketTimeout: number): Promise<ServerListeningState> {
+async function startServer(app: Express.Application, port: number): Promise<ServerListeningState> {
+  let keepAlive = true;
+  const socketTimeout = 5000;
   const wrapperApp = Express();
   wrapperApp.set("x-powered-by", false);
 
@@ -158,9 +160,7 @@ async function startServer(app: Express.Application, port: number, keepAlive: bo
 
 export type ServerConfig = {
   bundlePath: string;
-  keepAlive: boolean;
   port: number;
-  socketTimeout: number;
 }
 
 export type ParsedArgsResult = ServerConfig | string;
@@ -188,22 +188,11 @@ export function parseArgs(args: string[]): ParsedArgsResult {
 
   const argv: any = yargs(args)
     .strict()
-    .option("socketTimeout", {
-      demand: true,
-      describe: "Close open sockets after <timeout> milliseconds of inactivity.",
-      type: "number",
-      coerce: coerceInteger("socketTimeout"),
-    })
     .option("port", {
       demand: true,
       describe: "Port to listen on.",
       type: "number",
       coerce: coerceInteger("port"),
-    })
-    .option("keepAlive", {
-      demand: true,
-      describe: "Enable HTTP Persisent Connections.",
-      type: "boolean",
     })
     .option("bundlePath", {
       demand: true,
@@ -232,7 +221,7 @@ export async function run(config: ServerConfig): Promise<void> {
   const manifest = await readManifest(config.bundlePath);
   const app = buildApplication(manifest, config.bundlePath);
 
-  const serverListeningState = await startServer(app, config.port, config.keepAlive, config.socketTimeout);
+  const serverListeningState = await startServer(app, config.port);
 
   console.log(`Server started; Port=${config.port} PID=${process.pid}`);
 


### PR DESCRIPTION
Removes the socketTimeout and keepAlive options in favor of hardcoding
them in the server runner.