### PR TITLE
Uses minimist to parse command line args

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,22 +8,22 @@
   "dependencies": {
     "express": "^4.14.0",
     "jsonschema": "^1.1.1",
+    "minimist": "^1.2.0",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "source-map-support": "^0.4.6",
-    "tslib": "^1.2.0",
-    "yargs": "^6.5.0"
+    "tslib": "^1.2.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",
     "@types/express": "^4.0.34",
     "@types/extract-text-webpack-plugin": "^2.0.0",
+    "@types/minimist": "^1.2.0",
     "@types/mocha": "^2.2.33",
     "@types/react": "^0.14.54",
     "@types/react-dom": "^0.14.19",
     "@types/webpack": "^2.0.0",
     "@types/webpack-dev-server": "^1.12.5",
-    "@types/yargs": "^6.3.3",
     "chai": "^3.5.0",
     "concurrently": "^3.1.0",
     "css-loader": "^0.23.1",

--- a/spec/server/MainSpec.ts
+++ b/spec/server/MainSpec.ts
@@ -30,12 +30,16 @@ describe("Main", () => {
       }
     });
 
-    it(`fails when port is missing`, () => {
+    it(`defaults when port is missing`, () => {
       const { "--port": _, ...args } = validArgs;
 
       const result = parseArgs(flatten(args));
 
-      expect(isParseArgsResultFail(result)).to.be.true;
+      if (isParseArgsResultSuccess(result)) {
+        expect(result.port).to.eql(8080);
+      } else {
+        expect("<success>").to.eql(result);
+      }
     });
 
     it(`fails when port is not a number`, () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,10 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-0.0.29.tgz#fbcfd330573b912ef59eeee14602bface630754b"
 
+"@types/minimist@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
+
 "@types/mocha@^2.2.33":
   version "2.2.33"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.33.tgz#d79a0061ec270379f4d9e225f4096fb436669def"
@@ -77,10 +81,6 @@
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-2.0.0.tgz#e7934a1c0bb628e1940f090c0afd2682817c1def"
   dependencies:
     "@types/uglify-js" "*"
-
-"@types/yargs@^6.3.3":
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-6.3.3.tgz#b088bf22c126ab3fa3b110e29318b3f47894c04d"
 
 abbrev@1:
   version "1.0.9"
@@ -3648,7 +3648,7 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
-string-width@^1.0.1, string-width@^1.0.2:
+string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   dependencies:
@@ -4237,12 +4237,6 @@ yargs-parser@^2.4.1:
     camelcase "^3.0.0"
     lodash.assign "^4.0.6"
 
-yargs-parser@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.0.tgz#6ced869cd05a3dca6a1eaee38b68aeed4b0b4101"
-  dependencies:
-    camelcase "^3.0.0"
-
 yargs@^4.7.1:
   version "4.8.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.8.1.tgz#c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0"
@@ -4261,25 +4255,6 @@ yargs@^4.7.1:
     window-size "^0.2.0"
     y18n "^3.2.1"
     yargs-parser "^2.4.1"
-
-yargs@^6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.5.0.tgz#a902e23a1f0fe912b2a03f6131b7ed740c9718ff"
-  dependencies:
-    camelcase "^3.0.0"
-    cliui "^3.2.0"
-    decamelize "^1.1.1"
-    get-caller-file "^1.0.1"
-    os-locale "^1.4.0"
-    read-pkg-up "^1.0.1"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^1.0.2"
-    which-module "^1.0.0"
-    window-size "^0.2.0"
-    y18n "^3.2.1"
-    yargs-parser "^4.2.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
Instead of yargs because it has a massive list of dependencies.